### PR TITLE
Fixing inner IP header checksum computation

### DIFF
--- a/lisp-control-plane-freebsd_v3.2b/plugin_openlisp.c
+++ b/lisp-control-plane-freebsd_v3.2b/plugin_openlisp.c
@@ -405,7 +405,7 @@ send_mr(int idx)
 		ih->ip_sum        = 0;         
 		ih->ip_src.s_addr = afi_addr_src.ip.address.s_addr;
 		ih->ip_dst.s_addr = eid->sin.sin_addr.s_addr;
-		ih->ip_sum = ip_checksum((unsigned short *)ih, ip_len);
+		ih->ip_sum        = ip_checksum((uint16_t *)ih, (ih->ip_hl)*2);
 		break;
 	case AF_INET6:
 		ip_len = (uint8_t *)ptr - (uint8_t *)ih;

--- a/lisp-control-plane-freebsd_v3.2b/udp.c
+++ b/lisp-control-plane-freebsd_v3.2b/udp.c
@@ -1357,9 +1357,9 @@ udp_request_get_port(void *data, uint16_t *port)
 	return (TRUE);
 }
 
-/* generate checksum of message */
-	ushort 
-ip_checksum (unsigned short *buf, int nwords)
+/* generate checksum of IP header; nwords is the length of the header measured in 16-bit words */
+	uint16_t
+ip_checksum (uint16_t *buf, int nwords)
 {
 	unsigned long sum;
 
@@ -1522,7 +1522,7 @@ udp_request_add(void *data, uint8_t security, uint8_t ddt,\
 		ih->ip_sum        = 0;         
 		ih->ip_src.s_addr = afi_addr_src.ip.address.s_addr;
 		ih->ip_dst.s_addr = afi_addr_dst.ip.address.s_addr;
-		ih->ip_sum 		  = htons(ip_checksum((unsigned short *)ih, (ih->ip_hl)*2));
+		ih->ip_sum 		  = ip_checksum((uint16_t *)ih, (ih->ip_hl)*2);
 		break;
 	case AF_INET6:
 		ip_len = (uint8_t *)rpk->curs - (uint8_t *) udp;


### PR DESCRIPTION
Encapsulated control packets have an "outer" and an "inner"
IP header. The checksum computation for the inner one is
currently wrong.

In plugin_openlisp.c, it is performed on the whole IP packet,
instead of the header only. In udp.c the length is correct,
but the subsequent htons is not necessary.

This is not a critical bug, since current LISP implementations
apparently do not check for the inner checksum when
decapsulating, but this behavior should not be relied upon.
Moreover, it gives an ugly orange-on-black color in Wireshark
captures.

This commit also changes the "unsigned short_" type of
ip_checksum argument to the almost equivalent "uint16_t_",
for maximum clarity and portability.

The fix is applied only to v3.2b folder, but it would be trivial to
extend it to other branches.
